### PR TITLE
update treasury balance

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ function HomeContent() {
   const [bitcoinPrice, setBitcoinPrice] = useState(0);
   const previousPriceRef = useRef(0);
   const [priceDirection, setPriceDirection] = useState<string | null>(null);
-  const [holding] = useState(8883);
+  const [holding] = useState(9032);
   const [holdingValue, setHoldingValue] = useState(0);
   
   // Calculate display length based on holding value


### PR DESCRIPTION
Mirrors squareup/bitcoin-web#10. Bumps treasury holding from 8883 to 9032 BTC.